### PR TITLE
Fixing extra zero being added in setValue()

### DIFF
--- a/code/DateSelectorField.php
+++ b/code/DateSelectorField.php
@@ -147,12 +147,15 @@ class DateSelectorField extends CompositeField {
 						break;
 				}
 			}
-			if ($d < 10) {
-				$d = '0'.$d;
+
+			// suffix zero if one is missing for single digit days/months
+			if($d < 10 && strlen($d) == 1) {
+				$d = '0' . $d;
 			}
-			if ($m < 10) {
-				$m = '0'.$m;
+			if($m < 10 && strlen($m) == 1) {
+				$m = '0' . $m;
 			}
+
 			$this->value = $y . '-' . $m . '-' . $d;
 		}
 

--- a/tests/DateSelectorFieldTest.php
+++ b/tests/DateSelectorFieldTest.php
@@ -1,0 +1,53 @@
+<?php
+class DateSelectorFieldTest extends SapphireTest {
+
+	public function testSetValueDateTime() {
+		$field = new DateSelectorField('Date');
+
+		$field->setValue(new DateTime('1980-01-01'));
+		$this->assertEquals('1980-01-01', $field->getValue());
+
+		$children = $field->getChildren();
+		$this->assertEquals('01', $children[0]->dataValue());
+		$this->assertEquals('01', $children[1]->dataValue());
+		$this->assertEquals('1980', $children[2]->dataValue());
+	}
+
+	public function testSetValueString() {
+		$field = new DateSelectorField('Date');
+
+		$field->setValue('1980-1-1');
+		$this->assertEquals('1980-01-01', $field->getValue());
+
+		$children = $field->getChildren();
+		$this->assertEquals('01', $children[0]->dataValue());
+		$this->assertEquals('01', $children[1]->dataValue());
+		$this->assertEquals('1980', $children[2]->dataValue());
+
+		$field->setValue('1980-01-01');
+		$this->assertEquals('1980-01-01', $field->getValue());
+
+		$children = $field->getChildren();
+		$this->assertEquals('01', $children[0]->dataValue());
+		$this->assertEquals('01', $children[1]->dataValue());
+		$this->assertEquals('1980', $children[2]->dataValue());
+	}
+
+	public function testSetValueArray() {
+		$field = new DateSelectorField('Date');
+
+		$field->setValue(array(
+			'Day' => 2,
+			'Month' => 10,
+			'Year' => 2000
+		));
+
+		$children = $field->getChildren();
+		$this->assertEquals('02', $children[0]->dataValue());
+		$this->assertEquals('10', $children[1]->dataValue());
+		$this->assertEquals('2000', $children[2]->dataValue());
+
+		$this->assertEquals('2000-10-02', $field->getValue());
+	}
+
+}


### PR DESCRIPTION
fe710b582 fixes zeros being added to values of the DateSelectorField,
but on cases where setValue() is being called, an extra zero is being
added to the value, so instead of 1980-01-01 it'll come out as
1980-001-001 instead.
