### PR TITLE
FIX: Fields with no modifier set fail to re-populate after a save

### DIFF
--- a/code/DateSelectorField.php
+++ b/code/DateSelectorField.php
@@ -23,10 +23,15 @@ class DateSelectorField extends CompositeField {
 	protected $year;
 
 	public function __construct($name, $title = null, $value = null, $modifier = null) {
-		$this->name = $name .'[' . $modifier . ']';
+		// Only set a modifier if one is provided
+		if ($modifier) {
+			$name = $name .'[' . $modifier . ']';
+			$this->modifier = $modifier;
+		}
 
+		$this->name = $name;
 		$this->setTitle($title);
-		$this->modifier = $modifier;
+
 		$dayArray = array(
 			0 => 'Day'
 		);
@@ -93,6 +98,7 @@ class DateSelectorField extends CompositeField {
 		Requirements::css('dnadesign/silverstripe-datedropdownselectorfield: css/admin.css');
 
 		parent::__construct($fields);
+		$this->setName($name);
 		$this->setValue($value);
 	}
 
@@ -104,10 +110,16 @@ class DateSelectorField extends CompositeField {
 	 * Set the field name
 	 */
 	public function setName($name) {
-		$this->name = $name . '[' . $this->modifier . ']';
+		if ($this->modifier) {
+			$this->name = $name . '[' . $this->modifier . ']';
+		} else {
+			$this->name = $name;
+		}
+
 		$this->day->setName($this->name . '[Day]');
 		$this->month->setName($this->name . '[Month]');
 		$this->year->setName($this->name . '[Year]');
+
 		return $this;
 	}
 


### PR DESCRIPTION
This is due to a new implementation of `Form::loadDataFrom()` which changes how array-keyed data is loaded (it only looks one array level deep).

Previous field names were:
* No modifier given: `DateOfBirth[][Day]`
* Modifier given: `DateOfBirth[Modifier][Day]`

New field names are:
* No modifier given: `DateOfBirth[Day]`
* Modifier given: `DateOfBirth[Modifier][Day]`

Note, I haven't tested with providing a modifier, but there is no change to this use case.